### PR TITLE
Migrate from aiocometd to aiocometd-noloop for Python 3.10+ compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-
-aiocometd==0.4.5
+aiocometd-noloop==0.4.9
 eliot==1.12.0
 eliot-tree==19.0.1
 pytz==2019.2

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author="Vitor Mazzi",
     author_email="vitor.mazzi@intelie.com.br",
     install_requires=[
-        "aiocometd>=0.4.5",
+        "aiocometd-noloop==0.4.9",
         "eliot>1",
         "eliot-tree",
         "pytz>=2019.2",


### PR DESCRIPTION
## Summary
This PR updates the CometD client dependency from `aiocometd` to `aiocometd-noloop` to ensure compatibility with Python 3.10 and later versions.

## Changes
- Replace `aiocometd` with `aiocometd-noloop==0.4.9` in:
  - `requirements.txt`
  - `setup.py` (install_requires)

## Motivation
The original `aiocometd` library has compatibility issues with Python 3.10+ due to changes in asyncio event loop handling. The `aiocometd-noloop` fork addresses these issues while maintaining the same API interface.

## Testing
- Verify that the package installs correctly with Python 3.10+
- Confirm that CometD connections work as expected

## Impact
- **Breaking**: None - the API remains the same
- **Compatibility**: Adds support for Python 3.10, 3.11, 3.12, and 3.13